### PR TITLE
Fixed issues making it difficult to self-host

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "tsdx watch",
+    "start": "node dist/index.js"
+    "watch": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
     "watch": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
-    "discord.js": "https://github.com/discordjs/discord.js#5e706941fcf2977ac73ed42d3207abe2364f64b1",
+    "discord.js": "git://github.com/discordjs/discord.js.git#5e706941fcf2977ac73ed42d3207abe2364f64b1",
     "dotenv": "^10.0.0",
     "luxon": "^2.0.1"
   }


### PR DESCRIPTION
Issues fixed: 

- `yarn start` now executes the built files instead of running it in "watch mode"
- discord.js dependency is now installed by a specific version descriptor. (broken before)