### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Discord bot that automatically tracks Discord builds and checks for new changes.
 
-> **Note:** This bot isn't meant to be hosted by you, the source code is just here for people to help work on it, therefore there will be support given on how to set it up.
+> **Note:** This bot isn't meant to be hosted by you, the source code is just here for people to help work on it, therefore there will be no support given on how to set it up.
 
 ## Official Server
 
-Join our [official server](https://discord.gg/mqjwhDemBt) if you want to receive Discord build updates.
+Join our [official server](https://discord.com/invite/mqjwhDemBt) if you want to receive Discord build updates.
 
 ## Contributing
 Feel free to add new features by forking and then [opening a pull request](https://github.com/NurMarvin/discord-previews-bot/compare). If you're not good at programming but still have an idea for a feature that could be added, feel free to [open an issue](https://github.com/NurMarvin/discord-previews-bot/issues/new).


### PR DESCRIPTION
> **Note:** This bot isn't meant to be hosted by you, the source code is just here for people to help work on it, therefore there will be support given on how to set it up.

I'm assuming this is supposed to say "there will be **no** support given", otherwise the disclaimer beforehand doesnt make much sense.


> Join our `[official server](https://discord.gg/mqjwhDemBt)`

discord.gg invites just redirect to discord.com/invite/ and are otherwise functionally identical. Plus some browsers complain about too many redirects (especially between different domains), so I swapped this for the discord.com variant.